### PR TITLE
Support macos, windows, and ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ windows-latest, macos-latest, ubuntu-latest ]
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: thebrowsercompany/gha-aws-ssm-get-parameter@main
+      - uses: actions/checkout@v4
+
+      - name: Run this action
+        uses: ./
         with:
           aws-role-to-assume: ${{ secrets.TEST_AWS_ROLE }}
           aws-role-session-name: AwsSsmGetParameterTest
@@ -26,33 +29,29 @@ jobs:
 
       - name: Assert parameter was saved
         id: assert
-        continue-on-error: true
-        if: runner.os == 'Windows'
-        shell: pwsh
+        shell: bash
         run: |
-          $AwsSsmParmeter=$(Get-Content ${{ github.workspace }}/aws-ssm-parameter.txt)
-          if ( $AwsSsmParameter -eq "" ) {
-            "save-to-filepath failed"
-            "failed=true" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          }
+          # Handle Windows path separators.
+          OUTPUT_FILE=$(sed "s/\\\/\//g" <<< "${{ github.workspace }}/aws-ssm-parameter.txt")
+          VAL_FROM_FILE=$(cat $OUTPUT_FILE)
+          VAL_FROM_ENV="$AWS_SSM_PARAMETER"
 
-          if ( $env:AWS_SSM_PARAMETER -eq "" ) {
-            "save-to-env-var failed"
-            "failed=true" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          }
+          if [[ -z "$VAL_FROM_FILE" ]]; then
+            echo "save-to-filepath failed"
+            exit 1
+          fi
 
-          if ( $AwsSsmParameter != $env:AWS_SSM_PARAMETER ) {
-            "parameter values do not match"
-            "failed=true" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          }
+          if [[ -z "$VAL_FROM_ENV" ]]; then
+            echo "save-to-env-var failed"
+            exit 1
+          fi
+
+          if [[ "$VAL_FROM_FILE" != "$VAL_FROM_ENV" ]]; then
+            echo "parameter values do not match"
+            exit 1
+          fi
 
       - name: Cleanup parameter
-        shell: pwsh
-        run: Remote-Item -Force ${{ github.workspace }}/aws-ssm-parameter.txt
-
-      - name: Fail
-        if: steps.assert.output.failed == 'true'
-        shell: pwsh
-        run: exit 1
-
-
+        if: always()
+        shell: bash
+        run: rm -f ${{ github.workspace }}/aws-ssm-parameter.txt

--- a/action.yml
+++ b/action.yml
@@ -38,23 +38,29 @@ runs:
         role-session-name: ${{ inputs.aws-role-session-name }}
 
     - name: Assert input parameters valid
-      shell: bash
       if: inputs.save-to-env-var == '' && inputs.save-to-filepath == ''
+      shell: bash
       run: |
         echo "::error ::Please specify either save-to-env-var or save-to-filepath as an input."
         exit 1
 
-    - name: Fetch parameter to environment (Windows)
-      if: runner.os == 'Windows' && inputs.save-to-env-var != ''
-      shell: pwsh
+    - name: Fetch parameter
+      id: parameter
+      shell: bash
       run: |
-        $PARAMETER_VALUE = (aws ssm get-parameter --with-decryption --name ${{ inputs.aws-ssm-parameter }} | ConvertFrom-Json).Parameter.Value
+        PARAMETER_VALUE="$(aws ssm get-parameter --with-decryption --name ${{ inputs.aws-ssm-parameter }} | jq -r '.Parameter.Value')"
         echo "::add-mask::$PARAMETER_VALUE"
-        echo "${{ inputs.save-to-env-var }}=$PARAMETER_VALUE" >> "$env:GITHUB_ENV"
+        echo "value=$PARAMETER_VALUE" >> "$GITHUB_OUTPUT"
 
-    - name: Fetch parameter to file (Windows)
-      if: runner.os == 'Windows' && inputs.save-to-filepath != ''
-      shell: pwsh
+    - name: Save parameter to environment
+      if: inputs.save-to-env-var != ''
+      shell: bash
+      run: echo "${{ inputs.save-to-env-var }}=${{ steps.parameter.outputs.value }}" >> "$GITHUB_ENV"
+
+    - name: Save parameter to file
+      if: inputs.save-to-filepath != ''
+      shell: bash
       run: |
-        $paramValue = (aws ssm get-parameter --with-decryption --name ${{ inputs.aws-ssm-parameter }} | ConvertFrom-Json).Parameter.Value
-        Set-Content -Path ${{ inputs.save-to-filepath }} -Value $paramValue
+        # Handle Windows path separators.
+        OUTPUT_FILE=$(sed "s/\\\/\//g" <<< "${{ inputs.save-to-filepath }}")
+        echo "${{ steps.parameter.outputs.value }}" > $OUTPUT_FILE


### PR DESCRIPTION
- Switches to bash for all steps.
- Fixes action and test to handle windows path separators.
- Add tests for each os.
- Use the current version of this action during tests (call actions/checkout and use './' as the action path)